### PR TITLE
ci: run manifest and dispatch jobs on ubuntu-slim

### DIFF
--- a/.github/workflows/python-linux.yaml
+++ b/.github/workflows/python-linux.yaml
@@ -54,22 +54,16 @@ jobs:
   ceres-manifest:
     needs: [ ceres ]
     name: Bind Ceres Solver images into a single one
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:
         platform: [ "manylinux", "musllinux" ]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.x'
-          cache: 'pip'
       - name: Login to registry
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Install deps
-        run: python3 -mpip install -r requirements.txt
       - name: Create and push
         run: ./build.py ${{ github.ref != 'refs/heads/master' && '--no-push' || '' }} --platform=${{ matrix.platform }} manifest --tag=ceres
 
@@ -104,22 +98,16 @@ jobs:
   gsl-manifest:
     needs: [ gsl ]
     name: Bind GSL images into a single one
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:
         platform: [ "manylinux" ]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.x'
-          cache: 'pip'
       - name: Login to registry
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Install deps
-        run: python3 -mpip install -r requirements.txt
       - name: Create and push
         run: ./build.py ${{ github.ref != 'refs/heads/master' && '--no-push' || '' }} --platform=${{ matrix.platform }} manifest --tag=gsl
 
@@ -160,22 +148,16 @@ jobs:
   latest-manifest:
     needs: [ latest ]
     name: Build latest images into a single manifest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     strategy:
       fail-fast: false
       matrix:
         platform: [ "manylinux", "musllinux" ]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: '3.x'
-          cache: 'pip'
       - name: Login to registry
         if: ${{ github.ref == 'refs/heads/master' }}
         run: docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-      - name: Install deps
-        run: python3 -mpip install -r requirements.txt
       - name: Create and push
         run: ./build.py ${{ github.ref != 'refs/heads/master' && '--no-push' || '' }} --platform=${{ matrix.platform }} manifest --tag=latest
 
@@ -183,7 +165,7 @@ jobs:
     needs: [ latest-manifest ]
     if: ${{ github.ref == 'refs/heads/master' }}
     name: Trigger publish.yaml workflow in light-curve-python repo
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v4


### PR DESCRIPTION
The three manifest jobs and the repository-dispatch job move to the single-CPU `ubuntu-slim` runner. The image builds stay put — `docker buildx` needs a daemon, which slim (an unprivileged container) doesn't have.

The manifest jobs also drop `setup-python` and `pip install -r requirements.txt`: `build.py`'s manifest path never reaches `pypa_image()`, the only caller of `current_cibw_images()` and so the only thing needing `cibuildwheel`. Verified on a clean Python 3.12 with nothing installed — `./build.py --platform=manylinux manifest --tag=ceres --help` parses and exits 0.

Slim ships the Docker client but no daemon, which is fine here:

- `docker login` falls back to `loginClientSide` when the daemon isn't responding (explicit in `docker/cli`).
- `docker manifest create` touches no daemon API, and `push` goes through `registryClient`/`PutManifest`.

⚠️ Note this PR can't fully exercise itself: `docker login` is gated on `refs/heads/master` and PRs pass `--no-push`, so only `docker manifest create` runs here. The login and push paths first execute on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)